### PR TITLE
Small fix to allow usage from Objective-C

### DIFF
--- a/libstud/uuid/uuid.hxx
+++ b/libstud/uuid/uuid.hxx
@@ -65,8 +65,14 @@ namespace stud
     //
     uuid () = default;
 
+    // nil is a keyword in objective-c
+#ifndef __OBJC__
     bool
     nil () const;
+#endif
+
+    bool
+    isNil () const;
 
     explicit operator bool () const;
 

--- a/libstud/uuid/uuid.ixx
+++ b/libstud/uuid/uuid.ixx
@@ -6,7 +6,7 @@ namespace stud
   // NOTE: the order of definitions is important to MinGW GCC (DLL linkage).
 
   inline bool uuid::
-  nil () const
+  isNil () const
   {
     return
       time_low  == 0 &&
@@ -18,10 +18,19 @@ namespace stud
       node[3] == 0 && node[4] == 0 && node[5] == 0;
   }
 
+  // nil is a keyword in objective-c
+#ifndef __OBJC__
+  inline bool uuid::
+  nil () const
+  {
+    return isNil ();
+  }
+#endif
+
   inline uuid::
   operator bool () const
   {
-    return !nil ();
+    return !isNil ();
   }
 
   inline void uuid::
@@ -172,7 +181,7 @@ namespace stud
   inline uuid::variant_type uuid::
   variant () const
   {
-    return nil ()
+    return isNil ()
       ? variant_type::dce
       : ((clock_seq_hir & 0x80) == 0 ? variant_type::ncs :
          (clock_seq_hir & 0x40) == 0 ? variant_type::dce :
@@ -183,7 +192,7 @@ namespace stud
   inline uuid::version_type uuid::
   version () const
   {
-    return nil ()
+    return isNil ()
       ? version_type::random
       : static_cast<version_type> ((time_hiv >> 12) & 0x0f);
   }


### PR DESCRIPTION
Hello, I really like your little UUID lib.

When using it with Objective-C, I encountered a name conflict with the 'nil' function since 'nil' is a reserved keyword in Objective-C. To resolve this, I:
1. Added an 'isNil' function as an alternative
2. Added preprocessor guards to make the 'nil' function unavailable when compiling with Objective-C
   (`#ifndef __OBJC__`)

This change maintains compatibility with existing C++ code.